### PR TITLE
Fixing Typo with variable name in CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -281,7 +281,7 @@ module.exports = async (command, flags) => {
             );
             const { plaidAccountIDToSync } = await inquirer.prompt({
                 type: "list",
-                name: "plaidAccountToSync",
+                name: "plaidAccountIDToSync",
                 message: `Which Plaid acount do you want to sync with "${actualAcct.name}"?`,
                 choices: syncChoices,
             });


### PR DESCRIPTION
This fixes an issue with the Plaid account selector not having a value. This makes the setup process fail to link a Plaid Account with an Actual Account.

The `name` key in the object passed to `inquirer.prompt` method will be the key of the value returned when a choice is made.